### PR TITLE
Implemented the "jsonselect" command-line tool.

### DIFF
--- a/jsonselect/README.md
+++ b/jsonselect/README.md
@@ -1,0 +1,46 @@
+jsonselect - Select JSON with class
+===================================
+
+Query JSON like you would query some CSS nodes.
+
+jsonselect is a command-line tool to apply JSONSelect filters to
+JSON through stdin, line by line.
+
+Usage
+-----
+
+Output from `jsonselect --help`:
+
+    Usage of jsonselect:
+      -i	Nicely indent any JSON output
+      -q	Keep strings quoted instead of unquoting them
+      -s	Put things on a single line
+
+From a `jsonfile` that looks like:
+
+    {"event": "My event", "properties": {"os_name": "Windows"}}
+    {"event": "My event", "properties": {"os_name": "Linux"}}
+
+Extract the `event` prop, one by line:
+
+    cat jsonfile | jsonselect .event
+
+Extract two lines for each incoming line, one is the `event` property, the other the [JSONPath](http://goessner.net/articles/JsonPath/) equivalent to `.properties.os_name`:
+
+    cat jsonfile | jsonselect .event ".properties .os_name"
+
+Same thing, on a single line, separated by `\t` characters:
+
+    cat jsonfile | jsonselect -s .event ".properties .os_name"
+
+By default, `jsonselect` displays each queried selector one line after
+the other.  It is thus possible that one record outputs a variable
+number of rows (since some properties can exist only in _some_
+records). Using `-s` ensures you have one line per matching record,
+but you need to deal with the `\t`.
+
+Nicely indented properties dictionary, prefixed with the `event` as quoted (-q) text:
+
+    cat jsonfile | jsonselect -q -i .event .properties
+
+Merely running `cat jsonfile | jsonselect -i` will display `:root` by default.

--- a/jsonselect/main.go
+++ b/jsonselect/main.go
@@ -1,29 +1,5 @@
 package main
 
-// jsonselect is a command-line tool to apply JSONSelect filters to
-// JSON through stdin, line by line.
-//
-// You can use as (eg. filtering Mixpanel-like event data):
-//
-// Extract the `event` prop, one by line:
-//
-//     cat jsonfile | jsonselect .event
-//
-// Extract two lines for each incoming line, one is the `event` property, the other the JSONPath equivalent to `.properties.os_name`
-//
-//     cat jsonfile | jsonselect .event ".properties .os_name"
-//
-// Same thing, on a single line, separated by \t characters:
-//
-//     cat jsonfile | jsonselect -s .event ".properties .os_name"
-//
-// Nicely indented properties dictionary, prefixed with the `event` as quoted (-q) text:
-//
-//     cat jsonfile | jsonselect -q -i .event .properties
-//
-//
-// Merely running `cat jsonfile | jsonselect -i` will display `:root` by default.
-
 import (
 	"bufio"
 	"encoding/json"

--- a/jsonselect/main.go
+++ b/jsonselect/main.go
@@ -2,6 +2,27 @@ package main
 
 // jsonselect is a command-line tool to apply JSONSelect filters to
 // JSON through stdin, line by line.
+//
+// You can use as (eg. filtering Mixpanel-like event data):
+//
+// Extract the `event` prop, one by line:
+//
+//     cat jsonfile | jsonselect .event
+//
+// Extract two lines for each incoming line, one is the `event` property, the other the JSONPath equivalent to `.properties.os_name`
+//
+//     cat jsonfile | jsonselect .event ".properties .os_name"
+//
+// Same thing, on a single line, separated by \t characters:
+//
+//     cat jsonfile | jsonselect -s .event ".properties .os_name"
+//
+// Nicely indented properties dictionary, prefixed with the `event` as quoted (-q) text:
+//
+//     cat jsonfile | jsonselect -q -i .event .properties
+//
+
+
 
 import (
 	"bufio"

--- a/jsonselect/main.go
+++ b/jsonselect/main.go
@@ -21,8 +21,8 @@ package main
 //
 //     cat jsonfile | jsonselect -q -i .event .properties
 //
-
-
+//
+// Merely running `cat jsonfile | jsonselect -i` will display `:root` by default.
 
 import (
 	"bufio"
@@ -47,9 +47,14 @@ func main() {
 
 	errored := false
 
+	args := flag.Args()
+	if len(args) == 0 {
+		args = append(args, ":root")
+	}
+
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
-		elements, err := elementsForAllPatterns(scanner.Text(), flag.Args())
+		elements, err := elementsForAllPatterns(scanner.Text(), args)
 		if err != nil {
 			log.Println("Error:", err)
 			return

--- a/jsonselect/main.go
+++ b/jsonselect/main.go
@@ -1,0 +1,96 @@
+package main
+
+// jsonselect is a command-line tool to apply JSONSelect filters to
+// JSON through stdin, line by line.
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	jsonselect "github.com/coddingtonbear/go-jsonselect"
+)
+
+func main() {
+	var singleLine bool
+	var quotedStrings bool
+	var indent bool
+
+	flag.BoolVar(&singleLine, "s", false, "Put things on a single line")
+	flag.BoolVar(&quotedStrings, "q", false, "Keep strings quoted instead of unquoting them")
+	flag.BoolVar(&indent, "i", false, "Nicely indent any JSON output")
+	flag.Parse()
+
+	errored := false
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		elements, err := elementsForAllPatterns(scanner.Text(), flag.Args())
+		if err != nil {
+			log.Println("Error:", err)
+			return
+		}
+
+		for i, el := range elements {
+			if i > 0 {
+				if singleLine {
+					fmt.Print("\t")
+				} else {
+					fmt.Print("\n")
+				}
+			}
+
+			stringElement, isString := el.(string)
+			if !quotedStrings && isString {
+				fmt.Print(stringElement)
+			} else {
+				var out []byte
+				if indent {
+					out, err = json.MarshalIndent(el, "", "  ")
+				} else {
+					out, err = json.Marshal(el)
+				}
+				if err != nil {
+					log.Printf("Error marshalling %v: %s\n", el, err)
+					errored = true
+				}
+
+				os.Stdout.Write(out)
+			}
+
+		}
+		fmt.Print("\n")
+
+	}
+	if scanner.Err() != nil {
+		log.Println("Error scanning file:", scanner.Err())
+		errored = true
+	}
+
+	if errored {
+		os.Exit(1)
+	}
+}
+
+func elementsForAllPatterns(body string, patterns []string) ([]interface{}, error) {
+	var out []interface{}
+	for _, pattern := range patterns {
+		parser, err := jsonselect.CreateParserFromString(body)
+		if err != nil {
+			return nil, fmt.Errorf("Error unmarshalling JSON, killing feed: %s", err)
+		}
+
+		elements, err := parser.GetValues(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing document: %s", err)
+		}
+		for _, el := range elements {
+			out = append(out, el)
+		}
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
This can be used to parse incoming streams of JSON documents, and print outputs

You can use as (eg. filtering Mixpanel-like event data):

Extract the `event` prop, one by line:

    cat jsonfile | jsonselect .event

Extract two lines for each incoming line, one is the `event` property, the other the JSONPath equivalent to `.properties.os_name`

    cat jsonfile | jsonselect .event ".properties .os_name"

Same thing, on a single line, separated by \t characters:

    cat jsonfile | jsonselect -s .event ".properties .os_name"

Nicely indented properties dictionary, prefixed with the `event` as quoted (-q) text:

    cat jsonfile | jsonselect -q -i .event .properties


